### PR TITLE
fix(client) : variable d'environnement VITE_API_URL

### DIFF
--- a/client/src/services/connexion.ts
+++ b/client/src/services/connexion.ts
@@ -1,7 +1,7 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 
 const connexion = new ApolloClient({
-  uri: import.meta.env.API_URL,
+  uri: import.meta.env.VITE_API_URL,
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
Correction d'une erreur de typo dans la variable d'environnement VITE_API_URL (qui était nommée API_URL)