### PR TITLE
fix(client): ajout d'un regex plus permissif et vidage du champ nom

### DIFF
--- a/client/src/components/ManageJuryAddRow.tsx
+++ b/client/src/components/ManageJuryAddRow.tsx
@@ -38,7 +38,7 @@ export default function ManageJuryAddRow({
   const handleNameValidation = () => {
     const value = nameRef.current && nameRef.current.value;
     return value
-      ? /.{5,100}/.test(value) && /^[A-Za-z0-9_-\s]+$/.test(value)
+      ? /.{5,100}/.test(value) && /^[A-Za-z0-9À-ÖØ-öø-ÿ@_-\s]+$/.test(value)
       : false;
   };
 
@@ -68,6 +68,8 @@ export default function ManageJuryAddRow({
           },
         });
         (await refetch)();
+
+        if (nameRef.current) nameRef.current.value = "";
       } catch {
         setMessage("Le nom doit être unique");
         setOpenAlert(true);


### PR DESCRIPTION
- Ajout d'un regex plus permissif incluant les caractères accentués et quelques caractères spéciaux dans le nom d'un jury
- Vidage du champ nom après ajout d'un jury