### PR TITLE
refacto: on ne peut voir que les jurys d'une compétition désormais

### DIFF
--- a/api/src/competition/competition.resolver.ts
+++ b/api/src/competition/competition.resolver.ts
@@ -27,14 +27,16 @@ export default class CompetitionResolver {
     return await Competition.find();
   }
 
-  @Query(() => [Competition])
+  @Query(() => Competition)
   async getCompetitionById(@Arg("competitionId") competitionId: number) {
-    return await Competition.find({
+    return await Competition.findOneOrFail({
       where: {
         id: competitionId,
       },
       relations: {
-        juries: true,
+        juries: {
+          users: true,
+        },
       },
     });
   }

--- a/api/src/seed_data/competitions.json
+++ b/api/src/seed_data/competitions.json
@@ -1,5 +1,15 @@
 [
-  { "name": "competitionA", "location": "Paris", "date": "2017-05-24" },
-  { "name": "competitionB", "location": "Montpellier", "date": "2021-06-02" },
-  { "name": "competitionC", "location": "Lyon", "date": "2024-09-23" }
+  {
+    "id": 3,
+    "name": "competitionA",
+    "location": "Paris",
+    "date": "2017-05-24"
+  },
+  {
+    "id": 1,
+    "name": "competitionB",
+    "location": "Montpellier",
+    "date": "2021-06-02"
+  },
+  { "id": 2, "name": "competitionC", "location": "Lyon", "date": "2024-09-23" }
 ]

--- a/api/src/seed_data/juries.json
+++ b/api/src/seed_data/juries.json
@@ -1,12 +1,12 @@
 [
   { "id": 1, "name": "Jury Willms", "competitionId": 1 },
-  { "id": 2, "name": "Super Jury", "competitionId": 1 },
-  { "id": 3, "name": "Mulhouse in da place", "competitionId": 1 },
-  { "id": 4, "name": "Pouros United", "competitionId": 1 },
+  { "id": 2, "name": "Super Jury", "competitionId": 3 },
+  { "id": 3, "name": "Mulhouse in da place", "competitionId": 3 },
+  { "id": 4, "name": "Pouros United", "competitionId": 2 },
   { "id": 5, "name": "Weimann Bros", "competitionId": 1 },
-  { "id": 6, "name": "Jury Vandervort", "competitionId": 1 },
-  { "id": 7, "name": "LegoLand Jury", "competitionId": 1 },
-  { "id": 8, "name": "Ghibli Jury", "competitionId": 1 },
-  { "id": 9, "name": "Jury Ashitaka", "competitionId": 1 },
-  { "id": 10, "name": "Vesoul Jury Inc", "competitionId": 1 }
+  { "id": 6, "name": "Jury Vandervort", "competitionId": 2 },
+  { "id": 7, "name": "LegoLand Jury", "competitionId": 2 },
+  { "id": 8, "name": "Ghibli Jury", "competitionId": 3 },
+  { "id": 9, "name": "Jury Ashitaka", "competitionId": 3 },
+  { "id": 10, "name": "Vesoul Jury Inc", "competitionId": 3 }
 ]

--- a/client/src/components/ManageJuryAddRow.tsx
+++ b/client/src/components/ManageJuryAddRow.tsx
@@ -1,11 +1,7 @@
 import { useRef, useState } from "react";
-import { ApolloQueryResult } from "@apollo/client";
 import { createPortal } from "react-dom";
-import {
-  Exact,
-  useCreateNewJuryMutation,
-  GetAllJuriesQuery,
-} from "../types/graphql-types";
+import { useCreateNewJuryMutation } from "../types/graphql-types";
+import { JuriesOfCompetitionRefetchType } from "../types/types";
 import {
   TableRow,
   TableCell,
@@ -15,14 +11,10 @@ import {
   Alert,
 } from "@mui/material";
 
-type refetchType = (
-  variables?: Partial<Exact<{ [key: string]: never }>> | undefined,
-) => Promise<ApolloQueryResult<GetAllJuriesQuery>>;
-
 export default function ManageJuryAddRow({
   refetch,
 }: {
-  refetch: refetchType;
+  refetch: JuriesOfCompetitionRefetchType;
 }) {
   const [createNewJury] = useCreateNewJuryMutation();
 

--- a/client/src/components/ManageJuryRow.tsx
+++ b/client/src/components/ManageJuryRow.tsx
@@ -1,16 +1,14 @@
 import { useState, useEffect } from "react";
-import { ApolloQueryResult } from "@apollo/client";
 import {
-  Exact,
   useGetUsersByRoleQuery,
   useAddUserToJuryMutation,
   useRemoveUserFromJuryMutation,
   useDeleteJuryMutation,
-  GetAllJuriesQuery,
   Jury,
   User,
   DeleteJuryMutation,
 } from "../types/graphql-types";
+import { JuriesOfCompetitionRefetchType } from "../types/types";
 import { useDialog } from "../hooks/useDialog";
 import { useNotification } from "../hooks/useNotification";
 import TableCell from "@mui/material/TableCell";
@@ -25,16 +23,12 @@ import { Box } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { red } from "@mui/material/colors";
 
-type refetchType = (
-  variables?: Partial<Exact<{ [key: string]: never }>> | undefined,
-) => Promise<ApolloQueryResult<GetAllJuriesQuery>>;
-
 export default function ManageJuryRow({
   jury,
   refetch,
 }: {
   jury: Jury;
-  refetch: refetchType;
+  refetch: JuriesOfCompetitionRefetchType;
 }) {
   const { notifySuccess, notifyError } = useNotification();
   const { askUser } = useDialog();

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -10,7 +10,7 @@ import Manage from "./pages/Manage.tsx";
 import TeamsManagement from "./pages/TeamsManagement.tsx";
 import JuriesManagement from "./pages/JuriesManagement.tsx";
 import CompetitionsManagement from "./pages/CompetitionsManagement.tsx";
-import SessionsManagement from "./pages/SessionsManagement.tsx"
+import SessionsManagement from "./pages/SessionsManagement.tsx";
 import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
@@ -34,10 +34,6 @@ const router = createBrowserRouter([
         element: <Outlet />,
         children: [
           {
-            path: "juries",
-            element: <JuriesManagement />,
-          },
-          {
             index: true,
             element: <Manage />,
           },
@@ -57,7 +53,11 @@ const router = createBrowserRouter([
                 path: ":competitionId/planning",
                 element: <SessionsManagement />,
               },
-            ]
+              {
+                path: ":competitionId/juries",
+                element: <JuriesManagement />,
+              },
+            ],
           },
         ],
       },

--- a/client/src/pages/JuriesManagement.tsx
+++ b/client/src/pages/JuriesManagement.tsx
@@ -1,4 +1,9 @@
-import { useGetAllJuriesQuery, Jury } from "../types/graphql-types";
+import { useParams } from "react-router";
+import {
+  useGetJuriesOfCompetitionQuery,
+  Jury,
+  GetCompetitionByIdQueryVariables,
+} from "../types/graphql-types";
 import ManageJuryAddRow from "../components/ManageJuryAddRow";
 import ManageJuryRow from "../components/ManageJuryRow";
 import Table from "@mui/material/Table";
@@ -8,10 +13,15 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
-import { Typography, Box } from "@mui/material";
+import { Typography, Box, Stack } from "@mui/material";
 
 export default function JuriesManagement() {
-  const { loading, error, data, refetch } = useGetAllJuriesQuery();
+  const { competitionId } = useParams<string>();
+  const { loading, error, data, refetch } = useGetJuriesOfCompetitionQuery({
+    variables: {
+      competitionId: parseInt(competitionId as string),
+    } as GetCompetitionByIdQueryVariables,
+  });
 
   if (loading) return <p>🥁 Loading...</p>;
   if (error) return <p>☠️ Error: {error.message}</p>;
@@ -24,9 +34,14 @@ export default function JuriesManagement() {
         alignItems="center"
         height="25vh"
       >
-        <Typography variant="h2" component="h1">
-          Gestion des jurys
-        </Typography>
+        <Stack spacing={1} sx={{ alignItems: "center" }}>
+          <Typography variant="h2" component="h1">
+            Gestion des jurys
+          </Typography>
+          <Typography variant="h4" component="h3">
+            Compétition : {data && data.getCompetitionById.name}
+          </Typography>
+        </Stack>
       </Box>
 
       <>
@@ -46,7 +61,7 @@ export default function JuriesManagement() {
             <TableBody>
               <ManageJuryAddRow refetch={refetch} />
               {data &&
-                data.getAllJuries.map((jury) => (
+                data.getCompetitionById.juries.map((jury) => (
                   <ManageJuryRow
                     refetch={refetch}
                     key={jury.id}

--- a/client/src/schemas/queries.ts
+++ b/client/src/schemas/queries.ts
@@ -15,6 +15,25 @@ export const GET_JURIES = gql`
   }
 `;
 
+export const GET_JURIES_OF_COMPETITION = gql`
+  query GetJuriesOfCompetition($competitionId: Float!) {
+    getCompetitionById(competitionId: $competitionId) {
+      id
+      name
+      location
+      juries {
+        id
+        name
+        users {
+          id
+          firstname
+          lastname
+        }
+      }
+    }
+  }
+`;
+
 export const GET_ALL_TEAMS = gql`
   query GetAllTeams {
     allTeams {

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -1,5 +1,10 @@
 import { RefObject } from "react";
-import { Exact, GetAllTeamsQuery, Team } from "./graphql-types";
+import {
+  Exact,
+  GetAllTeamsQuery,
+  Team,
+  GetJuriesOfCompetitionQuery,
+} from "./graphql-types";
 import { ApolloQueryResult } from "@apollo/client";
 
 // used to change display mode in tables
@@ -24,7 +29,7 @@ export type TeamRowProps = {
   team?: Team;
   mode: Mode;
   refetch: (
-    variables?: Partial<Exact<{ [key: string]: never }>> | undefined
+    variables?: Partial<Exact<{ [key: string]: never }>> | undefined,
   ) => Promise<ApolloQueryResult<GetAllTeamsQuery>>;
 };
 
@@ -38,3 +43,7 @@ export type DataHandlerResult = {
   success: boolean;
   message: string | null | undefined;
 };
+
+export type JuriesOfCompetitionRefetchType = (
+  variables?: Partial<Exact<{ competitionId: number }>> | undefined,
+) => Promise<ApolloQueryResult<GetJuriesOfCompetitionQuery>>;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/877bc589-b320-4e45-8d9e-69311cf012ae)

- désormais on visualise les jurys d'une compétations via une URL du type /manage/competitions/1/juries
- les fichiers de seed competitions.json et juries.json ont été mis à jour (il manquait les id dans celui des compétitions)