### PR TITLE
Hotfix session ux

### DIFF
--- a/client/src/components/SessionCell.tsx
+++ b/client/src/components/SessionCell.tsx
@@ -1,8 +1,16 @@
-import { MenuItem, Select, SelectChangeEvent, TableCell } from "@mui/material";
+import {
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  TableCell,
+  Typography,
+} from "@mui/material";
 import { useState } from "react";
 import { useSessionsOperations } from "../services/sessions";
 import { useNotification } from "../hooks/useNotification";
 import { MinimalTeam, MinimalSession, SessionCellProps } from "../types/types";
+import BtnLink from "./BtnLink";
 
 export default function SessionCell({
   initialSession,
@@ -24,7 +32,9 @@ export default function SessionCell({
   };
   const defaultTeam = initialSession ? initialSession.team : noTeam;
   const [selectedTeam, setSelectedTeam] = useState<MinimalTeam>(defaultTeam);
-  const [session, setSession] = useState<MinimalSession | undefined>(initialSession);
+  const [session, setSession] = useState<MinimalSession | undefined>(
+    initialSession
+  );
 
   const submitCreation = async (targetTeam: MinimalTeam) => {
     const { success, message, createdSession } = await handleAddSession(
@@ -98,11 +108,23 @@ export default function SessionCell({
         onChange={handleSelect}
       >
         <MenuItem value="disponible">-</MenuItem>
-        {teams?.map((team) => (
-          <MenuItem key={team.id} value={team.name}>
-            {team.name}
-          </MenuItem>
-        ))}
+        {teams?.length ? (
+          teams.map((team) => (
+            <MenuItem key={team.id} value={team.name}>
+              {team.name}
+            </MenuItem>
+          ))
+        ) : (
+          <Stack flexDirection="column" gap={1} alignItems="center" justifyContent="center" marginTop={2}>
+            <Typography variant="body2" color="textSecondary">
+              Aucune équipe pour cette compétition
+            </Typography>
+            <BtnLink
+              to={`/manage/competitions/${competitionId}/teams`}
+              content="ajouter des équipes"
+            />
+          </Stack>
+        )}
       </Select>
     </TableCell>
   );

--- a/client/src/pages/SessionsManagement.tsx
+++ b/client/src/pages/SessionsManagement.tsx
@@ -18,6 +18,7 @@ export default function CompetitionsManagement() {
 
   const { loading, error, data } = useGetCompetitionByIdQuery({
     variables: { competitionId: parseInt(competitionId as string) },
+    fetchPolicy: "network-only",
   });
 
   if (loading) return <p>Loading...</p>;


### PR DESCRIPTION
Hot fix UX pour ajouter un bouton s'il n'y a pas d'équipes dans la compétition 
![image](https://github.com/user-attachments/assets/0c510ca5-f6e2-42da-bffe-a095376ed209)

également, invalidation du cache pour la query des sessions ( sinon l'UI ne refléte pas le Back )